### PR TITLE
feat: add support of custom communication protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const referenceResolver = require("@json-schema-tools/reference-resolver").defau
 referenceResolver("#/properties/foo", { properties: { foo: 123 } }); // returns '123'
 referenceResolver("https://foo.com/", {}); // returns what ever json foo.com returns
 referenceResolver("../my-object.json", {}); // you get teh idea
-
+referenceResolver("custom-reference", {}, (ref) => { /* some logic to retrieve reference JSON */ }); // returns resolved reference using customLoader to load json definitions
 ```
 
 ### Contributing

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,5 @@
 import referenceResolver from "./index";
-import { NonJsonRefError, InvalidJsonPointerRefError, InvalidFileSystemPathError, InvalidRemoteURLError } from "./reference-resolver";
+import { NonJsonRefError, InvalidJsonPointerRefError, InvalidFileSystemPathError, InvalidRemoteURLError, CustomLoaderError } from "./reference-resolver";
 
 describe("referenceResolver", () => {
 
@@ -19,6 +19,16 @@ describe("referenceResolver", () => {
       {},
     );
     expect(resolvedRef.title).toBe("JSONSchema");
+  });
+
+  it("custom loader", async () => {
+    const schema = { title: 'custom protocol' };
+    const resolvedRef = await referenceResolver(
+      "custom-reference",
+      {},
+      () => Promise.resolve(schema)
+    );
+    expect(resolvedRef).toStrictEqual(schema);
   });
 
   it("errors on non-json", async () => {
@@ -86,6 +96,15 @@ describe("referenceResolver", () => {
       expect(e).toBeInstanceOf(InvalidRemoteURLError);
     }
   });
+
+  it("errors if custom loader fails load", async () => {
+    expect.assertions(1);
+    try {
+      await referenceResolver("custom-reference", {}, () => Promise.reject());
+    } catch (e) {
+      expect(e).toBeInstanceOf(CustomLoaderError);
+    }
+  })
 });
 
 


### PR DESCRIPTION
the new optional parameter `loader` is added to referenceResolver function. It
can be used to override the mechanism of loading JSON schemas. For an example it
is suitable for overriding original URIs to load corresponding schemas from
another resources or loading JSON schemas via protocols different from
http/https/fileSystem e.g. pub/sub one.

contains part of implementation of the issue #587