### PR TITLE
fix: This corrects the behavior for nested resolution for json schemas.

### DIFF
--- a/src/default-protocol-handler-map.ts
+++ b/src/default-protocol-handler-map.ts
@@ -3,7 +3,7 @@ import { InvalidRemoteURLError, NonJsonRefError } from "./errors";
 import { JSONSchema } from "@json-schema-tools/meta-schema";
 import fetch from "isomorphic-fetch";
 
-const fetchHandler = async (uri: string): Promise<JSONSchema> => {
+const fetchHandler = async (uri: string, root: JSONSchema): Promise<JSONSchema> => {
   let schemaReq;
   try {
     schemaReq = await fetch(uri);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -71,6 +71,15 @@ describe("referenceResolver", () => {
     expect(resolved.$ref).toBe("./src/test-schema.json");
   });
 
+  it("works with nested folders when using different root context", async () => {
+    expect.assertions(1);
+    const resolved = await referenceResolver
+      .resolve("./test-schema-1.json", {
+        "$ref": "./nestedtest/test-schema.json"
+      }) as JSONSchemaObject;
+    expect(resolved.$ref).toBe("./src/test-schema.json");
+  });
+
   it("errors on urls that arent real", async () => {
     expect.assertions(1);
     try {

--- a/src/reference-resolver.ts
+++ b/src/reference-resolver.ts
@@ -11,7 +11,7 @@ const isUrlLike = (s: string) => {
 }
 
 export interface ProtocolHandlerMap {
-  [protocol: string]: (uri: string) => Promise<JSONSchema | undefined>;
+  [protocol: string]: (uri: string, root: JSONSchema) => Promise<JSONSchema | undefined>;
 };
 
 export default class ReferenceResolver {
@@ -41,7 +41,7 @@ export default class ReferenceResolver {
     // protocol handler
     let relativePathSchema;
     try {
-      relativePathSchema = await this.protocolHandlerMap.file(hashlessRef);
+      relativePathSchema = await this.protocolHandlerMap.file(hashlessRef, root);
     } catch (e) {
       throw new NonJsonRefError({ $ref: ref }, e.message);
     }
@@ -57,7 +57,7 @@ export default class ReferenceResolver {
 
     for (const protocol of Object.keys(this.protocolHandlerMap)) {
       if (hashlessRef.startsWith(protocol)) {
-        const maybeSchema = await this.protocolHandlerMap[protocol](hashlessRef);
+        const maybeSchema = await this.protocolHandlerMap[protocol](hashlessRef, root);
 
         if (maybeSchema !== undefined) {
           let schema: JSONSchema = maybeSchema;


### PR DESCRIPTION
For example the old behavior relied on relative path from the process
directory instead of the schema definition directory as according to
the spec.

The interface change exposes receiving the parent/root schema
in the argument to custom protocol handlers. This allows the
user to read this schema and gain contextual information that
is useful for resolving issues like the aforementioned.